### PR TITLE
fix: add updates to support libp2p 2.0

### DIFF
--- a/exercises/1_hello_world/problem.md
+++ b/exercises/1_hello_world/problem.md
@@ -50,7 +50,7 @@ const node = await createLibp2p({
   transports: [
     tcp()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     tls()
   ],
   streamMuxers: [

--- a/exercises/1_hello_world/solution.js
+++ b/exercises/1_hello_world/solution.js
@@ -8,7 +8,7 @@ export default async function helloWorld (ma) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/exercises/2_streams/exercise.js
+++ b/exercises/2_streams/exercise.js
@@ -12,11 +12,11 @@ exercise.addVerifyProcessor(verifyProcessor(exercise, async (test) => {
   const expected = [2, 4, 8, 0.4, 6]
 
   const stream = {
-    source: async function * () {
+    source: (async function * () {
       yield * [1, 10, 2, 59, 7, 'hello', 9, 4, {}, 0.2, 8, () => {}, 14, 3]
-    }(),
+    }()),
     sink: async function (source) {
-      for await (const val of source ) {
+      for await (const val of source) {
         output.push(val)
       }
     }

--- a/exercises/3_custom_protocols/exercise.js
+++ b/exercises/3_custom_protocols/exercise.js
@@ -64,11 +64,10 @@ async function testRespond (test, libp2p, respond) {
     signal: AbortSignal.timeout(1000)
   })
 
-
   const input = [
     Uint8Array.from([8, 9, 0, 1]),
     Uint8Array.from([4, 5, 6, 7]),
-    Uint8Array.from([0, 1, 2, 3]),
+    Uint8Array.from([0, 1, 2, 3])
   ]
 
   const echoed = []

--- a/exercises/3_custom_protocols/solution.js
+++ b/exercises/3_custom_protocols/solution.js
@@ -10,7 +10,7 @@ export async function dial (ma, protocol, data) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [
@@ -39,7 +39,7 @@ export async function respond (protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/exercises/4_imperative_protocols/solution.js
+++ b/exercises/4_imperative_protocols/solution.js
@@ -9,7 +9,7 @@ export default async function imperativeProtocols (ma, protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/exercises/5_length_prefixed_data/solution.js
+++ b/exercises/5_length_prefixed_data/solution.js
@@ -10,7 +10,7 @@ export default async function lengthPrefixedData (ma, protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/exercises/6_structured_data/solution.js
+++ b/exercises/6_structured_data/solution.js
@@ -10,7 +10,7 @@ export default async function structuredData (ma, protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/exercises/7_rpc/solution.js
+++ b/exercises/7_rpc/solution.js
@@ -16,7 +16,7 @@ export async function finder (protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [
@@ -56,7 +56,7 @@ export async function resolver (ma, protocol) {
     transports: [
       tcp()
     ],
-    connectionEncryption: [
+    connectionEncrypters: [
       tls()
     ],
     streamMuxers: [

--- a/lib/libp2p.mjs
+++ b/lib/libp2p.mjs
@@ -12,7 +12,7 @@ export default await createLibp2p({
   transports: [
     tcp()
   ],
-  connectionEncryption: [
+  connectionEncrypters: [
     tls()
   ],
   streamMuxers: [

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 async function delay (ms) {
   await new Promise((resolve) => {
     setTimeout(() => {
@@ -17,7 +16,7 @@ async function bufferArraysEqual (arr1, arr2) {
 }
 
 function randomNumber (min, max) {
-  return Math.round(Math.random() * (max - min) + min);
+  return Math.round(Math.random() * (max - min) + min)
 }
 
 function randomString (length) {
@@ -34,9 +33,9 @@ function randomString (length) {
 function defer () {
   let resolve, reject
 
-  const promise = new Promise((res, rej) => {
-    resolve = res
-    reject = rej
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
   })
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/protocol-adventure",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Learn how to develop custom protocols with libp2p",
   "repository": {
     "type": "git",
@@ -15,9 +15,9 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@chainsafe/libp2p-yamux": "^6.0.2",
-    "@libp2p/tcp": "^9.1.1",
-    "@libp2p/tls": "^1.1.1",
+    "@chainsafe/libp2p-yamux": "^7.0.1",
+    "@libp2p/tcp": "^10.0.11",
+    "@libp2p/tls": "^2.0.10",
     "cborg": "^4.2.2",
     "chalk": "^5.3.0",
     "it-byte-stream": "^1.0.12",
@@ -25,7 +25,7 @@
     "it-map": "^3.1.1",
     "it-pipe": "^3.0.1",
     "it-rpc": "^1.0.1",
-    "libp2p": "^1.8.0",
+    "libp2p": "^2.2.1",
     "patch-package": "^8.0.0",
     "shortid": "^2.2.8",
     "uint8-varint": "^2.0.4",


### PR DESCRIPTION


## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

Closes https://github.com/libp2p/js-libp2p-protocol-adventure/issues/1 

Updates the `connectionEncryption` to `connectionEncrypters` given the breaking changes introduced in libp2p 2.0

## Notes and Open Questions

@achingbrain what's the best way to test these changes

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works