### PR TITLE
fix: include exercises in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "files": [
     "index.js",
-    "examples",
+    "exercises",
     "i18n",
     "lib",
     "patches"


### PR DESCRIPTION
Include exercises otherwise they don't get installed.

Fixes #4

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works